### PR TITLE
Set 01.html as default landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
             </header>
 
             <main class="flex-1 overflow-x-hidden overflow-y-auto bg-gray-100">
-                <iframe id="content-frame" src="welcome.html" class="w-full h-full border-0" name="content-frame"></iframe>
+                <iframe id="content-frame" src="01.html" class="w-full h-full border-0" name="content-frame"></iframe>
             </main>
         </div>
     </div>
@@ -134,9 +134,10 @@
                 });
             });
 
-            // Tự động active link đầu tiên khi tải trang
+            // Tự động tải và active link đầu tiên khi tải trang
             if(menuLinks.length > 0) {
-                menuLinks[1].classList.add('active-link');
+                contentFrame.src = menuLinks[0].getAttribute('data-target');
+                menuLinks[0].classList.add('active-link');
             }
         });
     </script>


### PR DESCRIPTION
## Summary
- Load `01.html` by default in the main iframe and highlight the first menu item.

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adcf409c50832bb2bd10515814d28c