### PR TITLE
Fix print button on ca_tong_hop page

### DIFF
--- a/ca_tong_hop.html
+++ b/ca_tong_hop.html
@@ -186,10 +186,12 @@
     // Init
     renderCards('');
 
-    // Search
-    searchEl.addEventListener('input', (e) => {
-      renderCards(e.target.value || '');
-    });
+    // Search (optional – only if search element exists)
+    if (searchEl) {
+      searchEl.addEventListener('input', (e) => {
+        renderCards(e.target.value || '');
+      });
+    }
 
     // Print
     document.getElementById('printBtn').addEventListener('click', () => window.print());


### PR DESCRIPTION
## Summary
- Prevent JavaScript error from missing search element in ca_tong_hop.html
- Ensure Print button initializes even when no search box exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ed448b2c832b8f5bf7e0064c677c