### PR TITLE
fix: tighten flip card height in psychosis overview

### DIFF
--- a/02.html
+++ b/02.html
@@ -8,9 +8,9 @@
   <style>
     /* Flip card fix: đảm bảo nội dung không bị ngược khi lật */
     .flip { perspective: 1000px; }
-    .flip-inner { transform-style: preserve-3d; transition: transform .6s; }
+    .flip-inner { display: grid; transform-style: preserve-3d; transition: transform .6s; }
     .flip.is-flipped .flip-inner { transform: rotateY(180deg); }
-    .flip-face { backface-visibility: hidden; -webkit-backface-visibility: hidden; }
+    .flip-face { grid-area: 1/1; backface-visibility: hidden; -webkit-backface-visibility: hidden; }
     .flip-back { transform: rotateY(180deg); }
     /* Smooth accordion */
     .accordion-content { max-height: 0; overflow: hidden; transition: max-height .35s ease; }


### PR DESCRIPTION
## Summary
- Refine flip card CSS in `02.html` so front and back occupy the same grid area, eliminating extra vertical space when flipping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ee39eb14832b81f64cad4301d0d3