### PR TITLE
Add tooltips to sidebar icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,13 +83,13 @@
                 </div>
             </nav>
             <div class="flex p-4 space-x-4 text-white">
-                <a href="https://drive.google.com/drive/folders/101148IK_8lVlL1TJ_Sl2Wf65XZYjSt6G?usp=drive_link" target="_blank" rel="noopener noreferrer" aria-label="Google Drive">
+                <a href="https://drive.google.com/drive/folders/101148IK_8lVlL1TJ_Sl2Wf65XZYjSt6G?usp=drive_link" target="_blank" rel="noopener noreferrer" aria-label="Google Drive" title="Tài liệu môn học">
                     <i class="fab fa-google-drive text-2xl"></i>
                 </a>
-                <a href="https://drive.google.com/drive/folders/1w2fUZrEokw5GuZX3ZnP9bu53DLWpLmDI" target="_blank" rel="noopener noreferrer" aria-label="Audio">
+                <a href="https://drive.google.com/drive/folders/1w2fUZrEokw5GuZX3ZnP9bu53DLWpLmDI" target="_blank" rel="noopener noreferrer" aria-label="Audio" title="Records by Hoàng Vũ">
                     <i class="fas fa-file-audio text-2xl"></i>
                 </a>
-                <a href="https://open.spotify.com/show/22VZyXfAXz6T75O7WWCKEY?si=vYHfMqtlSxe59lIN2btPiw" target="_blank" rel="noopener noreferrer" aria-label="Spotify">
+                <a href="https://open.spotify.com/show/22VZyXfAXz6T75O7WWCKEY?si=vYHfMqtlSxe59lIN2btPiw" target="_blank" rel="noopener noreferrer" aria-label="Spotify" title="Đối thoại thú vị">
                     <i class="fab fa-spotify text-2xl"></i>
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- add descriptive tooltips for Google Drive, audio, and Spotify sidebar icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28f5ecd84832bbc33e9cce729c5b0