### PR TITLE
Add tooltips to sidebar icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,14 +83,17 @@
                 </div>
             </nav>
             <div class="flex p-4 space-x-4 text-white">
-                <a href="https://drive.google.com/drive/folders/101148IK_8lVlL1TJ_Sl2Wf65XZYjSt6G?usp=drive_link" target="_blank" rel="noopener noreferrer" aria-label="Google Drive">
+                <a href="https://drive.google.com/drive/folders/101148IK_8lVlL1TJ_Sl2Wf65XZYjSt6G?usp=drive_link" target="_blank" rel="noopener noreferrer" aria-label="Google Drive" class="relative group">
                     <i class="fab fa-google-drive text-2xl"></i>
+                    <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-700 rounded opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap">Tài liệu môn học</span>
                 </a>
-                <a href="https://drive.google.com/drive/folders/1w2fUZrEokw5GuZX3ZnP9bu53DLWpLmDI" target="_blank" rel="noopener noreferrer" aria-label="Audio">
+                <a href="https://drive.google.com/drive/folders/1w2fUZrEokw5GuZX3ZnP9bu53DLWpLmDI" target="_blank" rel="noopener noreferrer" aria-label="Audio" class="relative group">
                     <i class="fas fa-file-audio text-2xl"></i>
+                    <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-700 rounded opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap">Records by Hoàng Vũ</span>
                 </a>
-                <a href="https://open.spotify.com/show/22VZyXfAXz6T75O7WWCKEY?si=vYHfMqtlSxe59lIN2btPiw" target="_blank" rel="noopener noreferrer" aria-label="Spotify">
+                <a href="https://open.spotify.com/show/22VZyXfAXz6T75O7WWCKEY?si=vYHfMqtlSxe59lIN2btPiw" target="_blank" rel="noopener noreferrer" aria-label="Spotify" class="relative group">
                     <i class="fab fa-spotify text-2xl"></i>
+                    <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-700 rounded opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap">Đối thoại thú vị</span>
                 </a>
             </div>
         </aside>


### PR DESCRIPTION
## Summary
- add visible hover tooltips for Google Drive, audio, and Spotify sidebar icons using Tailwind classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28f5ecd84832bbc33e9cce729c5b0