### PR TITLE
Anchor sidebar icons to bottom with margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 </head>
 <body class="bg-gray-100 font-sans text-sm md:text-base">
     <div class="flex h-screen overflow-hidden">
-        <aside id="sidebar" class="bg-gray-800 text-gray-100 w-64 space-y-6 py-7 px-2 absolute inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 z-30 h-screen overflow-y-auto">
+        <aside id="sidebar" class="bg-gray-800 text-gray-100 w-64 space-y-6 py-7 px-2 absolute inset-y-0 left-0 transform -translate-x-full md:relative md:translate-x-0 z-30 h-screen overflow-y-auto flex flex-col">
                 <span class="text-xl md:text-2xl font-extrabold">Tâm Bệnh học</span>
 
             </br>
@@ -110,7 +110,7 @@
                     </div>
                 </div>
             </nav>
-            <div class="flex p-4 space-x-4 text-white">
+            <div class="flex p-4 space-x-4 text-white mt-auto mb-10">
 
                     <i class="fab fa-google-drive text-2xl"></i>
                     <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-700 rounded opacity-0 group-hover:opacity-100 pointer-events-none whitespace-nowrap">Tài liệu môn học</span>


### PR DESCRIPTION
## Summary
- Keep sidebar icons fixed at the bottom of the menu with a 40px margin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b1f8a41c832b8f6b51ffe2708c29