### PR TITLE
Clarify quiz submit button behavior in Claude HTML pages

### DIFF
--- a/02_Claude.html
+++ b/02_Claude.html
@@ -935,7 +935,7 @@
                         </div>`
                     ).join('')}
                     <div style="margin-top: 20px;">
-                        <button class="btn" onclick="submitAnswer()" id="submit-btn" disabled>Trả Lời</button>
+                        <button type="button" class="btn" onclick="submitAnswer()" id="submit-btn" disabled>Trả Lời</button>
                         <button class="btn" onclick="nextQuestion()" id="next-btn" style="display: none;">Câu Tiếp Theo</button>
                     </div>
                     <div id="explanation" style="display: none; margin-top: 20px; padding: 20px; background: #e8f5e8; border-radius: 10px;">

--- a/05_Claude.html
+++ b/05_Claude.html
@@ -300,7 +300,7 @@
                             
                             <div id="quiz-questions-container" class="hidden">
                                 <div class="text-center mt-6">
-                                    <button id="submit-quiz-btn" disabled class="bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                                    <button id="submit-quiz-btn" type="button" disabled class="bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                                         Nộp bài
                                     </button>
                                 </div>
@@ -425,7 +425,7 @@
                         `).join('')}
                     </div>
                     <div class="text-center mt-6">
-                        <button id="submit-quiz-btn" disabled class="bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                        <button id="submit-quiz-btn" type="button" disabled class="bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                             Nộp bài
                         </button>
                     </div>


### PR DESCRIPTION
## Summary
- Ensure quiz submission button in 02_Claude.html uses `type="button"` to avoid unintended form submission
- Apply the same `type="button"` adjustment for the quiz submission buttons in 05_Claude.html

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2c20ce2b4832bac35694816c49a1b