### PR TITLE
feat: move cheatsheet out of test section

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                     </div>
                     <div class="submenu text-sm ml-4 mt-1 hidden">
                         <a href="#" class="menu-link block py-2 px-4 rounded transition duration-200 hover:bg-gray-600" data-target="01_Claude.html">
-                            Các tiếp cận TBH 
+                            Các tiếp cận TBH
                         </a>
                         <a href="#" class="menu-link block py-2 px-4 rounded transition duration-200 hover:bg-gray-600" data-target="02_Claude.html">
                             Phổ loạn thần 
@@ -79,14 +79,16 @@
                     </div>
                 </div>
                 <div>
+                    <a href="#" class="menu-link block py-2 px-4 rounded transition duration-200 hover:bg-gray-600" data-target="cheatsheet.html">
+                        Cheatsheet
+                    </a>
+                </div>
+                <div>
                     <div class="section-header flex justify-between items-center cursor-pointer py-2.5 px-4 rounded transition duration-200 hover:bg-gray-700">
                         Kiểm tra
                         <i class="fas fa-chevron-down"></i>
                     </div>
                     <div class="submenu text-sm ml-4 mt-1 hidden">
-                        <a href="#" class="menu-link block py-2 px-4 rounded transition duration-200 hover:bg-gray-600" data-target="cheatsheet.html">
-                            Cheatsheet
-                        </a>
                         <a href="#" class="menu-link block py-2 px-4 rounded transition duration-200 hover:bg-gray-600" data-target="quiz.html">
                             Tổng hợp
                         </a>


### PR DESCRIPTION
## Summary
- move Cheatsheet menu link out of the Kiểm tra section to its own top-level entry.
- keep Kiểm tra section focused on quiz and case links.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57d18f7c8832b848d49841aa5d6e9